### PR TITLE
Add comparator methods to stops and routes

### DIFF
--- a/src/main/java/dev/katsute/onemta/MTAImpl.java
+++ b/src/main/java/dev/katsute/onemta/MTAImpl.java
@@ -112,62 +112,8 @@ final class MTAImpl extends MTA {
 
     // subway methods
 
-    String resolveSubwayLine(final String route_id){
-        final String route = route_id.toUpperCase();
-
-        switch(route){
-            case "A":
-            case "C":
-            case "E":
-
-            case "B":
-            case "D":
-            case "F":
-            case "M":
-
-            case "G":
-
-            case "J":
-            case "Z":
-
-            case "N":
-            case "Q":
-            case "R":
-            case "W":
-
-            case "L":
-
-            case "1":
-            case "2":
-            case "3":
-            case "4":
-            case "5":
-            case "6":
-            case "7":
-            case "GS":
-                return route.toUpperCase();
-            case "FS":
-            case "SF":
-            case "SR":
-                return "FS";
-            case "FX":
-            case "5X":
-            case "6X":
-            case "7X":
-                return String.valueOf(route.toUpperCase().charAt(0));
-            case "9":
-                return "GS";
-            case "S":
-            case "SI":
-            case "SIR":
-                return "SI";
-            default:
-                return null;
-        }
-    }
-
     FeedMessage resolveSubwayFeed(final String route_id){
-        final String route = Objects.requireNonNull(resolveSubwayLine(route_id), "Subway route with ID '" + route_id + "' not found");
+        final String route = Objects.requireNonNull(MTASchema_Subway.resolveSubwayLine(route_id), "Subway route with ID '" + route_id + "' not found");
         switch(route){
             case "A":
             case "C":
@@ -216,7 +162,7 @@ final class MTAImpl extends MTA {
 
     @Override
     public final Subway.Route getSubwayRoute(final String route_id){
-        return MTASchema_Subway.asRoute(this, Objects.requireNonNull(resolveSubwayLine(Objects.requireNonNull(route_id, "Route ID must not be null")), "Failed to find subway route with id '" + route_id + "'"));
+        return MTASchema_Subway.asRoute(this, Objects.requireNonNull(MTASchema_Subway.resolveSubwayLine(Objects.requireNonNull(route_id, "Route ID must not be null")), "Failed to find subway route with id '" + route_id + "'"));
     }
 
     @Override

--- a/src/main/java/dev/katsute/onemta/MTASchema_Bus.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Bus.java
@@ -26,11 +26,18 @@ import dev.katsute.onemta.types.TransitAlertPeriod;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static dev.katsute.onemta.bus.Bus.*;
 
 @SuppressWarnings({"SpellCheckingInspection", "ConstantConditions"})
 abstract class MTASchema_Bus extends MTASchema {
+
+    private static final Pattern type = Pattern.compile("^[X]|[XC+]$", Pattern.CASE_INSENSITIVE);
+
+    static String stripType(final String route){
+        return type.matcher(route).replaceAll("");
+    }
 
     static Route asRoute(final MTA mta, final String route_id){
         return asRoute(mta, route_id, null);
@@ -118,6 +125,7 @@ abstract class MTASchema_Bus extends MTASchema {
                                             routeLongName.contains("Select Bus Service");
             private final Boolean express = route_id.startsWith("X") ||
                                             route_id.endsWith("X") ||
+                                            route_id.endsWith("C") ||
                                             routeShortName.startsWith("X") ||
                                             routeShortName.endsWith("X") ||
                                             routeLongName.contains("Express");
@@ -188,7 +196,7 @@ abstract class MTASchema_Bus extends MTASchema {
             @Override
             public final boolean isExactRoute(final Object object){
                 if(object instanceof Route)
-                    return getRouteID().equals(((Route) object).getRouteID());
+                    return getRouteID().equalsIgnoreCase(((Route) object).getRouteID());
                 else if(object instanceof String)
                     return getRouteID().equalsIgnoreCase(object.toString());
                 else
@@ -197,9 +205,12 @@ abstract class MTASchema_Bus extends MTASchema {
 
             @Override
             public final boolean isSameRoute(final Object object){
-                // todo: strip express and SBS+ denotation then compare
-
-                return false;
+                if(object instanceof Route)
+                    return stripType(getRouteID()).equalsIgnoreCase(stripType(((Route) object).getRouteID()));
+                else if(object instanceof String)
+                    return stripType(getRouteID()).equalsIgnoreCase(stripType(object.toString()));
+                else
+                    return false;
             }
 
             // live feed
@@ -420,7 +431,7 @@ abstract class MTASchema_Bus extends MTASchema {
             @Override
             public final boolean isExactStop(final Object object){
                 if(object instanceof Stop)
-                    return getStopID().equals(((Stop) object).getStopID());
+                    return getStopID().toString().equalsIgnoreCase(((Stop) object).getStopID().toString());
                 else if(object instanceof String)
                     return getStopID().toString().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)

--- a/src/main/java/dev/katsute/onemta/MTASchema_Bus.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Bus.java
@@ -158,7 +158,7 @@ abstract class MTASchema_Bus extends MTASchema {
                 return routeTextColor;
             }
 
-            // onemta
+            // onemta methods
 
             @Override
             public final Boolean isSelectBusService(){
@@ -183,6 +183,23 @@ abstract class MTASchema_Bus extends MTASchema {
             @Override
             public final TransitAgency getAgency(){
                 return agency;
+            }
+
+            @Override
+            public final boolean isExactRoute(final Object object){
+                if(object instanceof Route)
+                    return getRouteID().equals(((Route) object).getRouteID());
+                else if(object instanceof String)
+                    return getRouteID().equalsIgnoreCase(object.toString());
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameRoute(final Object object){
+                // todo: strip express and SBS+ denotation then compare
+
+                return false;
             }
 
             // live feed
@@ -375,6 +392,26 @@ abstract class MTASchema_Bus extends MTASchema {
                 }
                 return alerts.toArray(new Alert[0]);
             }
+
+            // onemta methods
+
+            @Override
+            public final boolean isExactStop(final Object object){
+                if(object instanceof Stop)
+                    return getStopID().equals(((Stop) object).getStopID());
+                else if(object instanceof String)
+                    return getStopID().toString().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getStopID().equals(object);
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameStop(final Object object){
+                return isExactStop(object);
+            }
+
 
             // Java
 

--- a/src/main/java/dev/katsute/onemta/MTASchema_LIRR.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_LIRR.java
@@ -150,7 +150,7 @@ abstract class MTASchema_LIRR extends MTASchema {
             @Override
             public final boolean isExactRoute(final Object object){
                 if(object instanceof Route)
-                    return getRouteID().equals(((Route) object).getRouteID());
+                    return getRouteID().toString().equalsIgnoreCase(((Route) object).getRouteID().toString());
                 else if(object instanceof String)
                     return getRouteID().toString().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
@@ -341,11 +341,11 @@ abstract class MTASchema_LIRR extends MTASchema {
             @Override
             public final boolean isExactStop(final Object object){
                 if(object instanceof Stop)
-                    return getStopID().equals(((Stop) object).getStopID());
+                    return getStopID().toString().equalsIgnoreCase(((Stop) object).getStopID().toString());
                 else if(object instanceof String)
                     return getStopID().toString().equalsIgnoreCase(((String) object)) || getStopCode().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
-                    return getStopID().equals(object) || getStopCode().equals(object.toString());
+                    return getStopID().equals(object) || getStopCode().equalsIgnoreCase(object.toString());
                 else
                     return false;
             }

--- a/src/main/java/dev/katsute/onemta/MTASchema_LIRR.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_LIRR.java
@@ -137,6 +137,25 @@ abstract class MTASchema_LIRR extends MTASchema {
                 return alerts.toArray(new LIRR.Alert[0]);
             }
 
+            // onemta methods
+
+            @Override
+            public final boolean isExactRoute(final Object object){
+                if(object instanceof Route)
+                    return getRouteID().equals(((Route) object).getRouteID());
+                else if(object instanceof String)
+                    return getRouteID().toString().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getRouteID().equals(object);
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameRoute(final Object object){
+                return isExactRoute(object);
+            }
+
             // Java
 
             @Override
@@ -293,6 +312,25 @@ abstract class MTASchema_LIRR extends MTASchema {
                     this.alerts = alerts;
                 }
                 return alerts.toArray(new LIRR.Alert[0]);
+            }
+
+            // onemta methods
+
+            @Override
+            public final boolean isExactStop(final Object object){
+                if(object instanceof Stop)
+                    return getStopID().equals(((Stop) object).getStopID());
+                else if(object instanceof String)
+                    return getStopID().toString().equalsIgnoreCase(((String) object)) || getStopCode().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getStopID().equals(object) || getStopCode().equals(object.toString());
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameStop(final Object object){
+                return isExactStop(object);
             }
 
             // Java

--- a/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
@@ -132,7 +132,7 @@ abstract class MTASchema_MNR extends MTASchema {
             @Override
             public final boolean isExactRoute(final Object object){
                 if(object instanceof Route)
-                    return getRouteID().equals(((Route) object).getRouteID());
+                    return getRouteID().toString().equalsIgnoreCase(((Route) object).getRouteID().toString());
                 else if(object instanceof String)
                     return getRouteID().toString().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
@@ -311,7 +311,7 @@ abstract class MTASchema_MNR extends MTASchema {
             @Override
             public final boolean isExactStop(final Object object){
                 if(object instanceof Stop)
-                    return getStopID().equals(((Stop) object).getStopID());
+                    return getStopID().toString().equalsIgnoreCase(((Stop) object).getStopID().toString());
                 else if(object instanceof String)
                     return getStopID().toString().equalsIgnoreCase(((String) object)) || getStopCode().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)

--- a/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
@@ -315,7 +315,7 @@ abstract class MTASchema_MNR extends MTASchema {
                 else if(object instanceof String)
                     return getStopID().toString().equalsIgnoreCase(((String) object)) || getStopCode().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
-                    return getStopID().equals(object) || getStopCode().equals(object.toString());
+                    return getStopID().equals(object) || getStopCode().equalsIgnoreCase(object.toString());
                 else
                     return false;
             }

--- a/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_MNR.java
@@ -119,6 +119,25 @@ abstract class MTASchema_MNR extends MTASchema {
                 return alerts.toArray(new MNR.Alert[0]);
             }
 
+            // onemta methods
+
+            @Override
+            public final boolean isExactRoute(final Object object){
+                if(object instanceof Route)
+                    return getRouteID().equals(((Route) object).getRouteID());
+                else if(object instanceof String)
+                    return getRouteID().toString().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getRouteID().equals(object);
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameRoute(final Object object){
+                return isExactRoute(object);
+            }
+
             // Java
 
             @Override
@@ -263,6 +282,25 @@ abstract class MTASchema_MNR extends MTASchema {
                     this.alerts = alerts;
                 }
                 return alerts.toArray(new MNR.Alert[0]);
+            }
+
+            // onemta methods
+
+            @Override
+            public final boolean isExactStop(final Object object){
+                if(object instanceof Stop)
+                    return getStopID().equals(((Stop) object).getStopID());
+                else if(object instanceof String)
+                    return getStopID().toString().equalsIgnoreCase(((String) object)) || getStopCode().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getStopID().equals(object) || getStopCode().equals(object.toString());
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameStop(final Object object){
+                return isExactStop(object);
             }
 
             // Java

--- a/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
@@ -32,7 +32,7 @@ import static dev.katsute.onemta.subway.Subway.*;
 @SuppressWarnings("SpellCheckingInspection")
 abstract class MTASchema_Subway extends MTASchema {
 
-    private static final Pattern direction = Pattern.compile("N|S$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern direction = Pattern.compile("[NS]$", Pattern.CASE_INSENSITIVE);
 
     static String stripDirection(final String stop){
         return direction.matcher(stop).replaceAll("");
@@ -233,11 +233,11 @@ abstract class MTASchema_Subway extends MTASchema {
             @Override
             public final boolean isExactRoute(final Object object){
                 if(object instanceof Route)
-                    return getRouteID() != null && getRouteID().equals(((Route) object).getRouteID());
+                    return getRouteID() != null && getRouteID().equalsIgnoreCase(((Route) object).getRouteID());
                 else if(object instanceof String)
                     return getRouteID() != null && getRouteID().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
-                    return getRouteID() != null && getRouteID().equals(object.toString());
+                    return getRouteID() != null && getRouteID().equalsIgnoreCase(object.toString());
                 else
                     return false;
             }
@@ -360,7 +360,7 @@ abstract class MTASchema_Subway extends MTASchema {
                                     // check if this stop is en route
                                     if(
                                         stopDirection == null
-                                        ? stu.getStopId().equalsIgnoreCase(stop_id + "N") || stu.getStopId().equalsIgnoreCase(stop_id + "S")
+                                        ? stripDirection(stu.getStopId()).equalsIgnoreCase(stripDirection(stop_id))
                                         : stu.getStopId().equalsIgnoreCase(stop_id)
                                     ){
                                         tripUpdate  = entity.getTripUpdate();
@@ -416,11 +416,11 @@ abstract class MTASchema_Subway extends MTASchema {
             @Override
             public final boolean isExactStop(final Object object){
                 if(object instanceof Stop)
-                    return getStopID().equals(((Stop) object).getStopID());
+                    return getStopID().equalsIgnoreCase(((Stop) object).getStopID());
                 else if(object instanceof String)
                     return getStopID().equalsIgnoreCase(((String) object));
                 else if(object instanceof Number)
-                    return getStopID().equals(object.toString());
+                    return getStopID().equalsIgnoreCase(object.toString());
                 else
                     return false;
             }
@@ -428,11 +428,11 @@ abstract class MTASchema_Subway extends MTASchema {
             @Override
             public final boolean isSameStop(final Object object){
                 if(object instanceof Stop)
-                    return stripDirection(getStopID()).equals(stripDirection(((Stop) object).getStopID()));
+                    return stripDirection(getStopID()).equalsIgnoreCase(stripDirection(((Stop) object).getStopID()));
                 else if(object instanceof String)
-                    return stripDirection(getStopID()).equals(stripDirection(((String) object)));
+                    return stripDirection(getStopID()).equalsIgnoreCase(stripDirection(((String) object)));
                 else if(object instanceof Number)
-                    return stripDirection(getStopID()).equals(object.toString());
+                    return stripDirection(getStopID()).equalsIgnoreCase(object.toString());
                 else
                     return false;
             }

--- a/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
@@ -47,6 +47,12 @@ abstract class MTASchema_Subway extends MTASchema {
                     : SubwayDirection.SOUTH;
     }
 
+    private static final Pattern express = Pattern.compile("[X]$", Pattern.CASE_INSENSITIVE);
+
+    private static String stripExpress(final String route){
+        return express.matcher(route).replaceAll("");
+    }
+
     static String resolveSubwayLine(final String route_id){
         if(route_id == null) return null;
 
@@ -82,16 +88,16 @@ abstract class MTASchema_Subway extends MTASchema {
             case "6":
             case "7":
             case "GS":
+
+            case "FX":
+            case "5X":
+            case "6X":
+            case "7X":
                 return route;
             case "FS":
             case "SF":
             case "SR":
                 return "FS";
-            case "FX":
-            case "5X":
-            case "6X":
-            case "7X":
-                return String.valueOf(route.charAt(0));
             case "9":
                 return "GS";
             case "S":
@@ -186,7 +192,7 @@ abstract class MTASchema_Subway extends MTASchema {
                         // get next trip
                         if(entity.hasTripUpdate()){
                             if( // only include trips on this route
-                                entity.getTripUpdate().getTrip().getRouteId().replace("X", "").equals(route_id.replace("X", ""))
+                                stripExpress(entity.getTripUpdate().getTrip().getRouteId()).equalsIgnoreCase(stripExpress(route_id))
                             ){
                                 tripUpdate  = entity.getTripUpdate();
                                 tripVehicle = tripUpdate.getTrip().getExtension(NYCTSubwayProto.nyctTripDescriptor).getTrainId();
@@ -245,11 +251,17 @@ abstract class MTASchema_Subway extends MTASchema {
             @Override
             public final boolean isSameRoute(final Object object){
                 if(object instanceof Route)
-                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(((Route) object).getRouteID()));
+                    return resolveSubwayLine(getRouteID()) != null &&
+                           resolveSubwayLine(((Route) object).getRouteID()) != null &&
+                           stripExpress(resolveSubwayLine(getRouteID())).equalsIgnoreCase(stripExpress(resolveSubwayLine(((Route) object).getRouteID())));
                 else if(object instanceof String)
-                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(((String) object)));
+                    return resolveSubwayLine(getRouteID()) != null &&
+                           resolveSubwayLine((String) object) != null &&
+                           stripExpress(resolveSubwayLine(getRouteID())).equalsIgnoreCase(stripExpress(resolveSubwayLine((String) object)));
                 else if(object instanceof Number)
-                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(object.toString()));
+                    return resolveSubwayLine(getRouteID()) != null &&
+                           resolveSubwayLine(object.toString()) != null &&
+                           stripExpress(resolveSubwayLine(getRouteID())).equalsIgnoreCase(stripExpress(resolveSubwayLine(object.toString())));
                 else
                     return false;
             }

--- a/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
@@ -47,18 +47,76 @@ abstract class MTASchema_Subway extends MTASchema {
                     : SubwayDirection.SOUTH;
     }
 
+    static String resolveSubwayLine(final String route_id){
+        if(route_id == null) return null;
+
+        final String route = route_id.toUpperCase();
+
+        switch(route){
+            case "A":
+            case "C":
+            case "E":
+
+            case "B":
+            case "D":
+            case "F":
+            case "M":
+
+            case "G":
+
+            case "J":
+            case "Z":
+
+            case "N":
+            case "Q":
+            case "R":
+            case "W":
+
+            case "L":
+
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "GS":
+                return route;
+            case "FS":
+            case "SF":
+            case "SR":
+                return "FS";
+            case "FX":
+            case "5X":
+            case "6X":
+            case "7X":
+                return String.valueOf(route.charAt(0));
+            case "9":
+                return "GS";
+            case "S":
+            case "SI":
+            case "SIR":
+                return "SI";
+            default:
+                return null;
+        }
+    }
+
+    //
+
     static Route asRoute(final MTA mta, final String route_id){
         // find row
         final DataResource resource = getDataResource(mta, DataResourceType.Subway);
         final CSV csv               = resource.getData("routes.txt");
-        final List<String> row      = csv.getRow("route_id", cast(mta).resolveSubwayLine(route_id));
+        final List<String> row      = csv.getRow("route_id", resolveSubwayLine(route_id));
 
         // instantiate
         Objects.requireNonNull(row, "Failed to find subway route with id '" + route_id + "'");
 
         return new Route() {
 
-            private final String routeID        = cast(mta).resolveSubwayLine(route_id);
+            private final String routeID        = resolveSubwayLine(route_id);
             private final String routeShortName = row.get(csv.getHeaderIndex("route_short_name"));
             private final String routeLongName  = row.get(csv.getHeaderIndex("route_long_name"));
             private final String routeDesc      = row.get(csv.getHeaderIndex("route_desc"));
@@ -161,6 +219,33 @@ abstract class MTASchema_Subway extends MTASchema {
                 }
                 return alerts.toArray(new Subway.Alert[0]);
             }
+
+            // onemta methods
+
+            @Override
+            public final boolean isExactRoute(final Object object){
+                if(object instanceof Route)
+                    return getRouteID() != null && getRouteID().equals(((Route) object).getRouteID());
+                else if(object instanceof String)
+                    return getRouteID() != null && getRouteID().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getRouteID() != null && getRouteID().equals(object.toString());
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameRoute(final Object object){
+                if(object instanceof Route)
+                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(((Route) object).getRouteID()));
+                else if(object instanceof String)
+                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(((String) object)));
+                else if(object instanceof Number)
+                    return Objects.equals(resolveSubwayLine(getRouteID()), resolveSubwayLine(object.toString()));
+                else
+                    return false;
+            }
+
 
             // Java
 
@@ -304,6 +389,33 @@ abstract class MTASchema_Subway extends MTASchema {
                 }
                 return alerts.toArray(new Subway.Alert[0]);
             }
+
+            // onemta methods
+
+            @Override
+            public final boolean isExactStop(final Object object){
+                if(object instanceof Stop)
+                    return getStopID().equals(((Stop) object).getStopID());
+                else if(object instanceof String)
+                    return getStopID().equalsIgnoreCase(((String) object));
+                else if(object instanceof Number)
+                    return getStopID().equals(object.toString());
+                else
+                    return false;
+            }
+
+            @Override
+            public final boolean isSameStop(final Object object){
+                if(object instanceof Stop)
+                    return stripDirection(getStopID()).equals(stripDirection(((Stop) object).getStopID()));
+                else if(object instanceof String)
+                    return stripDirection(getStopID()).equals(stripDirection(((String) object)));
+                else if(object instanceof Number)
+                    return stripDirection(getStopID()).equals(object.toString());
+                else
+                    return false;
+            }
+
 
             // Java
 

--- a/src/main/java/dev/katsute/onemta/attribute/VehiclesReference.java
+++ b/src/main/java/dev/katsute/onemta/attribute/VehiclesReference.java
@@ -18,6 +18,7 @@
 
 package dev.katsute.onemta.attribute;
 
+import dev.katsute.onemta.subway.Subway;
 import dev.katsute.onemta.types.TransitVehicle;
 
 /**
@@ -32,7 +33,7 @@ import dev.katsute.onemta.types.TransitVehicle;
 public interface VehiclesReference<V extends TransitVehicle<?,?,?,?,?,?>> {
 
     /**
-     * Returns vehicles.
+     * Returns vehicles. For subway routes this will return both local and express trains; use {@link Subway.Vehicle#isExpress()} to check which trains are express.
      *
      * @return vehicles
      *

--- a/src/main/java/dev/katsute/onemta/types/TransitRoute.java
+++ b/src/main/java/dev/katsute/onemta/types/TransitRoute.java
@@ -29,7 +29,7 @@ import dev.katsute.onemta.attribute.VehiclesReference;
  * @param <A> transit alert type
  *
  * @since 1.0.0
- * @version 1.0.0
+ * @version 1.1.0
  * @author Katsute
  */
 public abstract class TransitRoute<RID, V extends TransitVehicle<?,?,?,?,?,?>, A extends TransitAlert<?,?,?,?>> implements VehiclesReference<V>, Alerts<A> {
@@ -79,5 +79,27 @@ public abstract class TransitRoute<RID, V extends TransitVehicle<?,?,?,?,?,?>, A
      * @since 1.0.0
      */
     public abstract String getRouteTextColor();
+
+    /**
+     * Returns if the route has the exact same route ID. Includes express and select bus service denotations.
+     *
+     * @param object route, route ID, or route code
+     * @return if route ID matches
+     *
+     * @since 1.1.0
+     * @see #isSameRoute(Object)
+     */
+    public abstract boolean isExactRoute(final Object object);
+
+    /**
+     * Returns if the route is the same route. Ignores express and select bus service denotations.
+     *
+     * @param object route, route ID, or route code
+     * @return if route is referring to the same route
+     *
+     * @since 1.1.0
+     * @see #isExactRoute(Object)
+     */
+    public abstract boolean isSameRoute(final Object object);
 
 }

--- a/src/main/java/dev/katsute/onemta/types/TransitStop.java
+++ b/src/main/java/dev/katsute/onemta/types/TransitStop.java
@@ -28,7 +28,7 @@ import dev.katsute.onemta.attribute.*;
  * @param <A> transit alert type
  *
  * @since 1.0.0
- * @version 1.0.0
+ * @version 1.1.0
  * @author Katsute
  */
 public abstract class TransitStop<SID, V extends TransitVehicle<?,?,?,?,?,?>, A extends TransitAlert<?,?,?,?>> implements Location, VehiclesReference<V>, Alerts<A> {
@@ -50,5 +50,27 @@ public abstract class TransitStop<SID, V extends TransitVehicle<?,?,?,?,?,?>, A 
      * @since 1.0.0
      */
     public abstract String getStopName();
+
+    /**
+     * Returns if the stop has the exact same stop ID. Includes stop direction.
+     *
+     * @param object stop, stop ID, or stop code
+     * @return if stop ID matches
+     *
+     * @since 1.1.0
+     * @see #isSameStop(Object)
+     */
+    public abstract boolean isExactStop(final Object object);
+
+    /**
+     * Returns if the stop is the same stop. Ignores stop direction.
+     *
+     * @param object stop, stop ID, or stop code
+     * @return if stop is referring to the same stop
+     *
+     * @since 1.1.0
+     * @see #isExactStop(Object)
+     */
+    public abstract boolean isSameStop(final Object object);
 
 }

--- a/src/test/java/dev/katsute/onemta/bus/TestBusRoute.java
+++ b/src/test/java/dev/katsute/onemta/bus/TestBusRoute.java
@@ -25,6 +25,53 @@ final class TestBusRoute {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(route.isExactRoute(null)));
+            annotateTest(() -> assertFalse(route.isExactRoute(999)));
+            annotateTest(() -> assertFalse(route.isExactRoute("999")));
+
+            annotateTest(() -> assertFalse(route.isExactRoute('x' + TestProvider.BUS_ROUTE)));
+            annotateTest(() -> assertFalse(route.isExactRoute('X' + TestProvider.BUS_ROUTE)));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'x')));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'X')));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'c')));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'C')));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(route.isExactRoute(route)));
+            annotateTest(() -> assertTrue(route.isExactRoute(mta.getBusRoute(TestProvider.BUS_ROUTE))));
+            annotateTest(() -> assertTrue(route.isExactRoute(TestProvider.BUS_ROUTE)));
+        }
+
+        @Test
+        final void testNotSame(){
+            annotateTest(() -> assertFalse(route.isSameRoute(null)));
+            annotateTest(() -> assertFalse(route.isSameRoute(999)));
+            annotateTest(() -> assertFalse(route.isSameRoute("999")));
+        }
+
+        @Test
+        final void testSame(){
+            annotateTest(() -> assertTrue(route.isSameRoute(route)));
+            annotateTest(() -> assertTrue(route.isSameRoute(mta.getBusRoute(TestProvider.BUS_ROUTE))));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE)));
+
+            annotateTest(() -> assertTrue(route.isSameRoute('x' + TestProvider.BUS_ROUTE)));
+            annotateTest(() -> assertTrue(route.isSameRoute('X' + TestProvider.BUS_ROUTE)));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'x')));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'X')));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'c')));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'C')));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Test

--- a/src/test/java/dev/katsute/onemta/bus/TestBusRoute.java
+++ b/src/test/java/dev/katsute/onemta/bus/TestBusRoute.java
@@ -39,6 +39,7 @@ final class TestBusRoute {
             annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'X')));
             annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'c')));
             annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + 'C')));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.BUS_ROUTE + '+')));
         }
 
         @Test
@@ -67,6 +68,7 @@ final class TestBusRoute {
             annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'X')));
             annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'c')));
             annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + 'C')));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.BUS_ROUTE + '+')));
         }
 
     }

--- a/src/test/java/dev/katsute/onemta/bus/TestBusStop.java
+++ b/src/test/java/dev/katsute/onemta/bus/TestBusStop.java
@@ -25,6 +25,26 @@ final class TestBusStop {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(stop.isExactStop(null)));
+            annotateTest(() -> assertFalse(stop.isExactStop(999)));
+            annotateTest(() -> assertFalse(stop.isExactStop("999")));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(stop.isExactStop(stop)));
+            annotateTest(() -> assertTrue(stop.isExactStop(mta.getBusStop(TestProvider.BUS_STOP))));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.BUS_STOP)));
+            annotateTest(() -> assertTrue(stop.isExactStop(String.valueOf(TestProvider.BUS_STOP))));
+        }
+
+    }
+
+    @Nested
     final class TestExtensions {
 
         @Nested

--- a/src/test/java/dev/katsute/onemta/lirr/TestLIRRRoute.java
+++ b/src/test/java/dev/katsute/onemta/lirr/TestLIRRRoute.java
@@ -27,6 +27,26 @@ final class TestLIRRRoute {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(route.isExactRoute(null)));
+            annotateTest(() -> assertFalse(route.isExactRoute(999)));
+            annotateTest(() -> assertFalse(route.isExactRoute("999")));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(route.isExactRoute(route)));
+            annotateTest(() -> assertTrue(route.isExactRoute(mta.getLIRRRoute(TestProvider.LIRR_ROUTE))));
+            annotateTest(() -> assertTrue(route.isExactRoute(TestProvider.LIRR_ROUTE)));
+            annotateTest(() -> assertTrue(route.isExactRoute(String.valueOf(TestProvider.LIRR_ROUTE))));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Nested

--- a/src/test/java/dev/katsute/onemta/lirr/TestLIRRStop.java
+++ b/src/test/java/dev/katsute/onemta/lirr/TestLIRRStop.java
@@ -27,6 +27,32 @@ final class TestLIRRStop {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(stop.isExactStop(null)));
+            annotateTest(() -> assertFalse(stop.isExactStop(999)));
+            annotateTest(() -> assertFalse(stop.isExactStop("999")));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(stop.isExactStop(stop)));
+            annotateTest(() -> assertTrue(stop.isExactStop(mta.getLIRRStop(TestProvider.LIRR_STOP))));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.LIRR_STOP)));
+            annotateTest(() -> assertTrue(stop.isExactStop(String.valueOf(TestProvider.LIRR_STOP))));
+        }
+
+        @Test
+        final void testStopCode(){
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.LIRR_STOP_CODE)));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.LIRR_STOP_CODE.toLowerCase())));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Nested

--- a/src/test/java/dev/katsute/onemta/mnr/TestMNRRoute.java
+++ b/src/test/java/dev/katsute/onemta/mnr/TestMNRRoute.java
@@ -27,6 +27,26 @@ final class TestMNRRoute {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(route.isExactRoute(null)));
+            annotateTest(() -> assertFalse(route.isExactRoute(999)));
+            annotateTest(() -> assertFalse(route.isExactRoute("999")));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(route.isExactRoute(route)));
+            annotateTest(() -> assertTrue(route.isExactRoute(mta.getMNRRoute(TestProvider.MNR_ROUTE))));
+            annotateTest(() -> assertTrue(route.isExactRoute(TestProvider.MNR_ROUTE)));
+            annotateTest(() -> assertTrue(route.isExactRoute(String.valueOf(TestProvider.MNR_ROUTE))));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Nested

--- a/src/test/java/dev/katsute/onemta/mnr/TestMNRStop.java
+++ b/src/test/java/dev/katsute/onemta/mnr/TestMNRStop.java
@@ -26,6 +26,32 @@ final class TestMNRStop {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(stop.isExactStop(null)));
+            annotateTest(() -> assertFalse(stop.isExactStop(999)));
+            annotateTest(() -> assertFalse(stop.isExactStop("999")));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(stop.isExactStop(stop)));
+            annotateTest(() -> assertTrue(stop.isExactStop(mta.getMNRStop(TestProvider.MNR_STOP))));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.MNR_STOP)));
+            annotateTest(() -> assertTrue(stop.isExactStop(String.valueOf(TestProvider.MNR_STOP))));
+        }
+
+        @Test
+        final void testStopCode(){
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.MNR_STOP_CODE)));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.MNR_STOP_CODE.toLowerCase())));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Nested

--- a/src/test/java/dev/katsute/onemta/subway/TestSubwayRoute.java
+++ b/src/test/java/dev/katsute/onemta/subway/TestSubwayRoute.java
@@ -25,6 +25,47 @@ final class TestSubwayRoute {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(route.isExactRoute(null)));
+            annotateTest(() -> assertFalse(route.isExactRoute(999)));
+            annotateTest(() -> assertFalse(route.isExactRoute("999")));
+
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.SUBWAY_ROUTE + 'x')));
+            annotateTest(() -> assertFalse(route.isExactRoute(TestProvider.SUBWAY_ROUTE + 'X')));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(route.isExactRoute(route)));
+            annotateTest(() -> assertTrue(route.isExactRoute(mta.getSubwayRoute(TestProvider.SUBWAY_ROUTE))));
+            annotateTest(() -> assertTrue(route.isExactRoute(Integer.valueOf(TestProvider.SUBWAY_ROUTE))));
+            annotateTest(() -> assertTrue(route.isExactRoute(TestProvider.SUBWAY_ROUTE)));
+        }
+
+        @Test
+        final void testNotSame(){
+            annotateTest(() -> assertFalse(route.isSameRoute(null)));
+            annotateTest(() -> assertFalse(route.isSameRoute(999)));
+            annotateTest(() -> assertFalse(route.isSameRoute("999")));
+        }
+
+        @Test
+        final void testSame(){
+            annotateTest(() -> assertTrue(route.isSameRoute(route)));
+            annotateTest(() -> assertTrue(route.isSameRoute(mta.getSubwayRoute(TestProvider.SUBWAY_ROUTE))));
+            annotateTest(() -> assertTrue(route.isSameRoute(Integer.valueOf(TestProvider.SUBWAY_ROUTE))));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.SUBWAY_ROUTE)));
+
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.SUBWAY_ROUTE + 'x')));
+            annotateTest(() -> assertTrue(route.isSameRoute(TestProvider.SUBWAY_ROUTE + 'X')));
+        }
+
+    }
+
+    @Nested
     final class ExtensionTests {
 
         @Test

--- a/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
+++ b/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
@@ -32,6 +32,57 @@ final class TestSubwayStop {
     }
 
     @Nested
+    final class ComparatorTests {
+
+        @Test
+        final void testNotExact(){
+            annotateTest(() -> assertFalse(stop.isExactStop(null)));
+            annotateTest(() -> assertFalse(stop.isExactStop(999)));
+            annotateTest(() -> assertFalse(stop.isExactStop("999")));
+
+            annotateTest(() -> assertFalse(stop.isExactStop(TestProvider.SUBWAY_STOP + 'n')));
+            annotateTest(() -> assertFalse(stop.isExactStop(TestProvider.SUBWAY_STOP + 'N')));
+            annotateTest(() -> assertFalse(stop.isExactStop(TestProvider.SUBWAY_STOP + 's')));
+            annotateTest(() -> assertFalse(stop.isExactStop(TestProvider.SUBWAY_STOP + 'S')));
+
+            annotateTest(() -> assertFalse(stop.isExactStop(stopN)));
+            annotateTest(() -> assertFalse(stop.isExactStop(stopS)));
+        }
+
+        @Test
+        final void testExact(){
+            annotateTest(() -> assertTrue(stop.isExactStop(stop)));
+            annotateTest(() -> assertTrue(stop.isExactStop(mta.getSubwayStop(TestProvider.SUBWAY_STOP))));
+            annotateTest(() -> assertTrue(stop.isExactStop(Integer.valueOf(TestProvider.SUBWAY_STOP))));
+            annotateTest(() -> assertTrue(stop.isExactStop(TestProvider.SUBWAY_STOP)));
+        }
+
+        @Test
+        final void testNotSame(){
+            annotateTest(() -> assertFalse(stop.isSameStop(null)));
+            annotateTest(() -> assertFalse(stop.isSameStop(999)));
+            annotateTest(() -> assertFalse(stop.isSameStop("999")));
+        }
+
+        @Test
+        final void testSame(){
+            annotateTest(() -> assertTrue(stop.isSameStop(stop)));
+            annotateTest(() -> assertTrue(stop.isSameStop(mta.getSubwayStop(TestProvider.SUBWAY_STOP))));
+            annotateTest(() -> assertTrue(stop.isSameStop(Integer.valueOf(TestProvider.SUBWAY_STOP))));
+            annotateTest(() -> assertTrue(stop.isSameStop(TestProvider.SUBWAY_STOP)));
+
+            annotateTest(() -> assertTrue(stop.isSameStop(TestProvider.SUBWAY_STOP + 'n')));
+            annotateTest(() -> assertTrue(stop.isSameStop(TestProvider.SUBWAY_STOP + 'N')));
+            annotateTest(() -> assertTrue(stop.isSameStop(TestProvider.SUBWAY_STOP + 's')));
+            annotateTest(() -> assertTrue(stop.isSameStop(TestProvider.SUBWAY_STOP + 'S')));
+
+            annotateTest(() -> assertTrue(stop.isSameStop(stopN)));
+            annotateTest(() -> assertTrue(stop.isSameStop(stopS)));
+        }
+
+    }
+
+    @Nested
     final class DirectionTests {
 
         @Nested


### PR DESCRIPTION
### Prerequisites
*If checks are not passed then the pull request will be closed.*

 - [x] I have checked that no other similar pull request already exists.
 - [x] My code follows the general code style as the rest of the code.
 - [x] I have checked that no sensitive information is exposed.
 - [x] Build compiles.
 - [x] Build passes test cases. https://github.com/KatsuteDev/OneMTA/actions/runs/2025033777

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - #35 
 - Add methods to check if stops are the exact or same
 - Add methods to check if routes are the exact or same
 - Add `C` as acceptable express bus denotation
 - Optimize subway vehicle filter
 - Fix subway route resolve