### PR TITLE
Retrieve transfer stations for subways

### DIFF
--- a/src/main/java/dev/katsute/onemta/CSV.java
+++ b/src/main/java/dev/katsute/onemta/CSV.java
@@ -66,23 +66,45 @@ class CSV {
         return new ArrayList<>(rows);
     }
 
-    public final List<String> getRow(final String keyHeader, final String key){
-        final int index = getHeaderIndex(keyHeader);
-        if(index == -1) return null;
+    public final List<String> getRow(final String keyHeader, final String keyValue){
+        final int keyIndex = getHeaderIndex(keyHeader);
+        if(keyIndex == -1) return null;
         for(final List<String> row : rows)
-            if(row.get(index).equals(key))
+            if(row.get(keyIndex).equals(keyValue))
                 return new ArrayList<>(row);
         return null;
     }
 
-    public final String getValue(final String keyHeader, final String key, final String valueHeader){
-         final int index = getHeaderIndex(valueHeader);
-        if(index == -1) return null;
-        final List<String> row = getRow(keyHeader, key);
+    public final List<List<String>> getRows(final String keyHeader, final String keyValue){
+        final int keyIndex = getHeaderIndex(keyHeader);
+        if(keyIndex == -1) return null;
+        final List<List<String>> match = new ArrayList<>();
+        for(final List<String> row : rows)
+            if(row.get(keyIndex).equals(keyValue))
+                match.add(new ArrayList<>(row));
+        return !match.isEmpty() ? match : null;
+    }
+
+    public final String getValue(final String keyHeader, final String keyValue, final String valueHeader){
+        final int valIndex = getHeaderIndex(valueHeader);
+        if(valIndex == -1) return null;
+        final List<String> row = getRow(keyHeader, keyValue);
         return
-            row != null && index < row.size()
-            ? row.get(index)
+            row != null && valIndex < row.size()
+            ? row.get(valIndex)
             : null;
+    }
+
+    public final String[] getValues(final String keyHeader, final String keyValue, final String valueHeader){
+        final int keyIndex = getHeaderIndex(keyHeader);
+        final int valIndex = getHeaderIndex(valueHeader);
+        if(keyIndex == -1 || valIndex == -1) return new String[0];
+        final List<List<String>> matches = getRows(keyHeader, keyValue);
+        final List<String> values = new ArrayList<>();
+        if(matches != null)
+            for(final List<String> match : matches)
+                values.add(match.get(valIndex));
+        return values.toArray(new String[0]);
     }
 
 }

--- a/src/main/java/dev/katsute/onemta/DataResource.java
+++ b/src/main/java/dev/katsute/onemta/DataResource.java
@@ -31,7 +31,7 @@ import java.util.zip.ZipFile;
  *
  * @see #create(DataResourceType, File)
  * @since 1.0.0
- * @version 1.0.0
+ * @version 1.1.0
  * @author Katsute
  */
 public abstract class DataResource {
@@ -79,6 +79,7 @@ public abstract class DataResource {
                             case "agency.txt":
                             case "routes.txt":
                             case "stops.txt":
+                            case "transfers.txt":
                                 try(final BufferedReader IN = new BufferedReader(new InputStreamReader(zip.getInputStream(entry)))){
                                     data.put(entry.getName(), new CSV(IN.lines().collect(Collectors.joining("\n"))));
                                 }catch(final IOException e){

--- a/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
+++ b/src/main/java/dev/katsute/onemta/MTASchema_Subway.java
@@ -337,6 +337,21 @@ abstract class MTASchema_Subway extends MTASchema {
                 return stopDirection;
             }
 
+            private List<Stop> transfers = null;
+
+            @Override
+            public final Stop[] getTransfers(){
+                if(transfers == null){
+                    final List<Stop> transfers = new ArrayList<>();
+                    final String raw = stripDirection(stopID);
+                    for(final String value : resource.getData("transfers.txt").getValues("from_stop_id", raw, "to_stop_id"))
+                        if(!value.equalsIgnoreCase(raw))
+                            transfers.add(mta.getSubwayStop(value));
+                    this.transfers = transfers;
+                }
+                return transfers.toArray(new Stop[0]);
+            }
+
             // live feed
 
             private List<Vehicle> vehicles = null;

--- a/src/main/java/dev/katsute/onemta/subway/Subway.java
+++ b/src/main/java/dev/katsute/onemta/subway/Subway.java
@@ -31,7 +31,7 @@ import dev.katsute.onemta.types.*;
  * @see TripStop
  * @see Alert
  * @since 1.0.0
- * @version 1.0.3
+ * @version 1.1.0
  * @author Katsute
  */
 public abstract class Subway {
@@ -51,10 +51,21 @@ public abstract class Subway {
      * Represents a subway stop.
      *
      * @since 1.0.0
-     * @version 1.0.0
+     * @version 1.1.0
      * @author Katsute
      */
-    public abstract static class Stop extends TransitStop<String,Vehicle,Alert> implements Direction<SubwayDirection> { }
+    public abstract static class Stop extends TransitStop<String,Vehicle,Alert> implements Direction<SubwayDirection> {
+
+        /**
+         * Returns a list of transfers.
+         *
+         * @return transfers
+         *
+         * @since 1.1.0
+         */
+        public abstract Stop[] getTransfers();
+
+    }
 
     /**
      * Represents a subway vehicle.

--- a/src/test/java/dev/katsute/onemta/TestCSV.java
+++ b/src/test/java/dev/katsute/onemta/TestCSV.java
@@ -94,7 +94,16 @@ final class TestCSV {
                 assertEquals("one", csv.getValue("key", "1", "value"));
                 assertEquals("two", csv.getValue("key", "2", "value"));
             });
+        }
 
+        @Test
+        final void testValueMultiple(){
+            annotateTest(() -> {
+                final CSV csv = new CSV("key,value\n1,one\n1,1\n2,two");
+
+                assertArrayEquals(new String[]{"one", "1"}, csv.getValues("key", "1", "value"));
+                assertArrayEquals(new String[]{"two"}, csv.getValues("key", "2", "value"));
+            });
         }
 
         @Test

--- a/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
+++ b/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
@@ -5,6 +5,8 @@ import dev.katsute.onemta.TestProvider;
 import dev.katsute.onemta.types.*;
 import org.junit.jupiter.api.*;
 
+import java.util.Arrays;
+
 import static dev.katsute.jcore.Workflow.*;
 import static dev.katsute.onemta.subway.Subway.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,6 +31,13 @@ final class TestSubwayStop {
         annotateTest(() -> VehicleValidation.requireVehicles(stop));
         annotateTest(() -> VehicleValidation.requireVehicles(stopN));
         annotateTest(() -> VehicleValidation.requireVehicles(stopS));
+    }
+
+    @Test
+    final void testTransfers(){
+        annotateTest(() -> assertNotEquals(0, stop.getTransfers().length));
+        for(final Stop transfer : stop.getTransfers())
+            annotateTest(() -> assertNotEquals(stop.getStopID(), transfer.getStopID()));
     }
 
     @Nested

--- a/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
+++ b/src/test/java/dev/katsute/onemta/subway/TestSubwayStop.java
@@ -5,8 +5,6 @@ import dev.katsute.onemta.TestProvider;
 import dev.katsute.onemta.types.*;
 import org.junit.jupiter.api.*;
 
-import java.util.Arrays;
-
 import static dev.katsute.jcore.Workflow.*;
 import static dev.katsute.onemta.subway.Subway.*;
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
### Prerequisites
*If checks are not passed then the pull request will be closed.*

 - [x] I have checked that no other similar pull request already exists.
 - [x] My code follows the general code style as the rest of the code.
 - [x] I have checked that no sensitive information is exposed.
 - [x] Build compiles.
 - [x] Build passes test cases. https://github.com/KatsuteDev/OneMTA/actions/runs/2025945633

### GitHub Copilot Disclaimer
*The use of GitHub Copilot is **strictly prohibited** on this repository.*

 - [x] This pull does not use GitHub Copilot.

### Changes Made
*List any changes made and/or other relevant issues.*

 - Implement #24*
 
   Transfer data is based solely on stop IDs, separate lines using the same stop will not count as a transfer. 
   Ex: Grand Central Station 4, 5, 6 trains all use stop code `631`, so transfers for this stop will only include 7, and GCT Shuttle.